### PR TITLE
Rename preset variable for clarity

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -46,7 +46,7 @@ public class RobotContainer {
   private final LEDManager ledManager = LEDManager.getInstance();
 
   // Instantiate the Preset manager
-  private final PresetManager preset = PresetManager.getInstance();
+  private final PresetManager presetManager = PresetManager.getInstance();
 
   //
   // ****************************************************************************************


### PR DESCRIPTION
Rename the preset variable to presetManager to improve code readability.